### PR TITLE
Compatibility with pip>=6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+V 0.2.2  2015-06-12
+
+    * Compatibility with pip 6+
+
 V 0.2.1  2015-01-12
 
     * Stop using dev version of "future"

--- a/limpyd/__init__.py
+++ b/limpyd/__init__.py
@@ -2,7 +2,7 @@
 power and the control of the Redis API, in a limpid way, with just as
 abstraction as needed."""
 
-VERSION = (0, 2, 1)
+VERSION = (0, 2, 2)
 
 __author__ = 'Yohan Boniface'
 __contact__ = "yb@enix.org"

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,18 @@ import sys
 
 import limpyd
 
+# The `session` argument for the `parse_requirements` function is available (but
+# optional) in pip 1.5, and mandatory in next versions
+try:
+    from pip.download import PipSession
+except ImportError:
+    parse_args = {}
+else:
+    parse_args = {'session': PipSession()}
+
 
 def get_requirements(source):
-    install_reqs = parse_requirements(source)
+    install_reqs = parse_requirements(source, **parse_args)
     return set([str(ir.req) for ir in install_reqs])
 
 


### PR DESCRIPTION
In pip 1.6/6, the `parse_requirements` expects a `session` argument (which is available but optional in pip 1.5)

This PR allow installing `redis-limpyd` with recent versions of pip