### PR TITLE
Make MetaRedisProxy a subclass of abc.ABCMeta

### DIFF
--- a/limpyd/fields.py
+++ b/limpyd/fields.py
@@ -5,6 +5,7 @@ from future.builtins import str
 from future.builtins import zip
 from future.utils import with_metaclass
 
+import abc
 from logging import getLogger
 from copy import copy
 
@@ -31,7 +32,7 @@ __all__ = [
 ]
 
 
-class MetaRedisProxy(type):
+class MetaRedisProxy(abc.ABCMeta):
     """
     This metaclass create the class normally, then takes a list of redis
     commands found in the "available_*" class attributes, and for each one


### PR DESCRIPTION
This will allow to do things like

```
class BaseModel(model.RedisModel, metaclass=abc.ABCMeta):
```

Without it or other hacks the above line gives

```
TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```